### PR TITLE
Fix timestamp generation

### DIFF
--- a/com.vzaar.api/OAuth/OAuthBase.cs
+++ b/com.vzaar.api/OAuth/OAuthBase.cs
@@ -380,19 +380,7 @@ namespace com.vzaar.api.OAuth
         {
             // Default implementation of UNIX time of the current UTC time
             TimeSpan ts = DateTime.UtcNow.Subtract((new DateTime(1970, 1, 1, 0, 0, 0, 0)));
-            string timeStamp = ts.TotalSeconds.ToString();
-
-            // Some timestamps contain a ',' instead of '.'
-            if (timeStamp.IndexOf(".") > -1)
-            {
-                timeStamp = timeStamp.Substring(0, timeStamp.IndexOf("."));
-            }
-            else
-            {
-                timeStamp = timeStamp.Substring(0, timeStamp.IndexOf(","));
-            }
-
-            return timeStamp;
+            return ((int)ts.TotalSeconds).ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
When the generated timestamp happens to be right on the second (ie. no
decimal places in `ts.TotalSeconds`), the current implementation will
fail with an `ArgumentOutOfRangeException` on `.Substring`.

This PR changes the implementation to the standard method for generating
unix timestamps in C# as seen here:
http://stackoverflow.com/questions/17632584/how-to-get-the-unix-timestamp-in-c-sharp
